### PR TITLE
COS-111 - Отображение дерева комментариев на фронте

### DIFF
--- a/packages/client/src/features/Comment/Comment.tsx
+++ b/packages/client/src/features/Comment/Comment.tsx
@@ -1,0 +1,41 @@
+import { Collapse } from "@mui/material";
+import { FC, useState } from "react";
+
+import { CommentFrameWidth, MinimizeWidth } from "@/shared/constants";
+
+import { GenericList } from "../GenericList/GenericList";
+import { TopicItem } from "../TopicItem/TopicItem";
+import { commentConverter } from "./converter";
+import { CommentComponentType } from "./types";
+
+export const Comment: FC<CommentComponentType> = props => {
+  const [open, setOpen] = useState(true);
+  const children = props.replies;
+  const hasChildren = children.length > 0;
+  const convertedComment = commentConverter(props);
+  const needWidth = props.width - MinimizeWidth;
+  const newWidth =
+    needWidth <= CommentFrameWidth.MIN ? CommentFrameWidth.MIN : needWidth;
+
+  const handleClick = () => {
+    setOpen(!open);
+  };
+
+  return (
+    <>
+      <TopicItem
+        canBeLiked
+        canBeReplied
+        key={convertedComment.id}
+        isBordered
+        {...convertedComment}
+        onExpand={hasChildren ? handleClick : undefined}
+      />
+      {hasChildren && (
+        <Collapse in={open} timeout="auto" unmountOnExit>
+          <GenericList items={children} width={newWidth} renderItem={Comment} />
+        </Collapse>
+      )}
+    </>
+  );
+};

--- a/packages/client/src/features/Comment/converter.ts
+++ b/packages/client/src/features/Comment/converter.ts
@@ -1,0 +1,7 @@
+import { CommentDataRequest } from "@/entities/forum/comments/api/types";
+
+export const commentConverter = (comment: CommentDataRequest) => ({
+  id: comment.id,
+  description: comment.comment,
+  comments_count: comment.replies.length,
+});

--- a/packages/client/src/features/Comment/types.ts
+++ b/packages/client/src/features/Comment/types.ts
@@ -1,0 +1,5 @@
+import { CommentDataRequest } from "@/entities/forum/comments/api/types";
+
+export type CommentComponentType = {
+  width: number;
+} & CommentDataRequest;

--- a/packages/client/src/features/CommentForm/CommentForm.tsx
+++ b/packages/client/src/features/CommentForm/CommentForm.tsx
@@ -1,0 +1,101 @@
+import EmojiEmotionsIcon from "@mui/icons-material/EmojiEmotions";
+import { Box, Button, IconButton, TextField } from "@mui/material";
+import { IEmojiData, IEmojiPickerProps } from "emoji-picker-react";
+import { useFormik } from "formik";
+import { FC, useState } from "react";
+import { useParams } from "react-router-dom";
+
+import { useAddCommentMutation } from "@/entities/forum/comments/api";
+import { useGetUserQuery } from "@/entities/user/model/api";
+import { commentValidation } from "@/shared/constants/validationShemas";
+
+import { CommentFormType } from "./types";
+
+let EmojiPicker: React.FC<IEmojiPickerProps> | undefined;
+if (typeof window !== "undefined") {
+  import("emoji-picker-react").then(_module => {
+    EmojiPicker = _module.default;
+  });
+}
+
+export const CommentForm: FC<CommentFormType> = ({ parentId }) => {
+  const { id } = useParams<{ id: string }>();
+  const forumId: number | null = id ? +id : null;
+
+  const { data: userData } = useGetUserQuery();
+  const [addComment] = useAddCommentMutation();
+
+  const formik = useFormik({
+    initialValues: {
+      comment: "",
+    },
+    validationSchema: commentValidation,
+    onSubmit: ({ comment }, helpers) => {
+      if (userData && forumId) {
+        addComment({
+          comment,
+          topicId: forumId,
+          authorId: userData.id,
+          parentId,
+        });
+        helpers.setFieldValue("comment", "", false);
+      }
+      setShowPicker(false);
+    },
+  });
+
+  const [showPicker, setShowPicker] = useState(false);
+  /* eslint-disable  @typescript-eslint/no-unused-vars */
+  const [chosenEmoji, setChosenEmoji] = useState<IEmojiData>();
+
+  const onEmojiClick = (
+    event: React.MouseEvent<Element, MouseEvent>,
+    emojiObject: IEmojiData
+  ) => {
+    setChosenEmoji(emojiObject); // нужно для ререндера компонента, инчае поле комментариев обновляется, только после закрытия эмоджи
+    /* eslint-disable  @typescript-eslint/no-non-null-assertion */
+    formik.values.comment = formik.values.comment + emojiObject!.emoji;
+  };
+
+  const handlePicker = () => setShowPicker(val => !val);
+
+  return (
+    <Box
+      component="form"
+      onSubmit={formik.handleSubmit}
+      sx={{
+        display: "flex",
+        flexDirection: "column",
+        alignItems: "end",
+        width: "95%",
+        my: 2,
+      }}>
+      <TextField
+        fullWidth
+        id="comment"
+        value={formik.values.comment}
+        name="comment"
+        label="Comment"
+        onChange={formik.handleChange}
+        error={formik.touched.comment && Boolean(formik.errors.comment)}
+        helperText={formik.touched.comment && formik.errors.comment}
+        multiline
+        rows={2}
+        sx={{
+          mb: 2,
+        }}
+      />
+      <Box>
+        <IconButton onClick={handlePicker}>
+          <EmojiEmotionsIcon sx={{ position: "relative" }} />
+        </IconButton>
+        {showPicker && EmojiPicker && (
+          <EmojiPicker onEmojiClick={onEmojiClick} />
+        )}
+        <Button variant="contained" size="large" type="submit">
+          Comment
+        </Button>
+      </Box>
+    </Box>
+  );
+};

--- a/packages/client/src/features/CommentForm/types.ts
+++ b/packages/client/src/features/CommentForm/types.ts
@@ -1,0 +1,3 @@
+export type CommentFormType = {
+  parentId?: number;
+};

--- a/packages/client/src/features/GenericList/GenericList.tsx
+++ b/packages/client/src/features/GenericList/GenericList.tsx
@@ -1,0 +1,31 @@
+import { Box, List } from "@mui/material";
+
+import { CommentFrameWidth } from "@/shared/constants";
+
+import { GenericListType } from "./types";
+
+export const GenericList = <T, U extends Record<string, unknown>>({
+  items,
+  width,
+  renderItem: RenderComponent,
+  ...args
+}: GenericListType<T> & U) => {
+  const listWidth = width ?? CommentFrameWidth.MAX;
+
+  return (
+    <List
+      sx={{
+        width: `${listWidth}%`,
+        ml: "auto",
+        overflowY: "auto",
+      }}>
+      {items.map((item, index) => {
+        return (
+          <Box key={`comment-${index}`}>
+            <RenderComponent {...item} width={listWidth} {...args} />
+          </Box>
+        );
+      })}
+    </List>
+  );
+};

--- a/packages/client/src/features/GenericList/types.ts
+++ b/packages/client/src/features/GenericList/types.ts
@@ -1,0 +1,7 @@
+import { FC } from "react";
+
+export type GenericListType<T> = {
+  items: T[];
+  renderItem: FC<any>;
+  width?: number;
+};

--- a/packages/client/src/features/TopicItem/types.ts
+++ b/packages/client/src/features/TopicItem/types.ts
@@ -3,9 +3,14 @@ import { AuthorOfTopicData } from "@/entities/forum/topics/api/types";
 export type TopicItemType = {
   id: number;
   isBordered?: boolean;
-  header?: () => JSX.Element | null;
+  hasLink?: boolean;
+  title?: string;
   author?: AuthorOfTopicData;
   description: string;
   comments_count?: number;
-  likesCount?: number;
+  likes_count?: number;
+  is_liked?: boolean;
+  canBeLiked?: boolean;
+  canBeReplied?: boolean;
+  onExpand?: () => void;
 };

--- a/packages/client/src/pages/ForumTopicPage/ForumTopicPage.tsx
+++ b/packages/client/src/pages/ForumTopicPage/ForumTopicPage.tsx
@@ -1,44 +1,28 @@
-import EmojiEmotionsIcon from "@mui/icons-material/EmojiEmotions";
 import ReplyIcon from "@mui/icons-material/Reply";
 import {
   Box,
-  Button,
   CircularProgress,
   IconButton,
-  List,
   Paper,
-  TextField,
   Typography,
 } from "@mui/material";
-import { IEmojiData, IEmojiPickerProps } from "emoji-picker-react";
-import { useFormik } from "formik";
-import { FC, useEffect, useState } from "react";
+import { FC, useEffect } from "react";
 import { useNavigate, useParams } from "react-router-dom";
 
-import {
-  useAddCommentMutation,
-  useGetCommentsQuery,
-} from "@/entities/forum/comments/api";
+import { useGetCommentsQuery } from "@/entities/forum/comments/api";
 import { useGetOneTopicQuery } from "@/entities/forum/topics/api";
-import { useGetUserQuery } from "@/entities/user/model/api";
+import { Comment } from "@/features/Comment/Comment";
+import { CommentForm } from "@/features/CommentForm/CommentForm";
+import { GenericList } from "@/features/GenericList/GenericList";
 import { TopicItem } from "@/features/TopicItem/TopicItem";
 import { RoutesName } from "@/shared/constants";
-import { commentValidation } from "@/shared/constants/validationShemas";
 import { MainLayout } from "@/shared/layouts/MainLayout";
-
-let EmojiPicker: React.FC<IEmojiPickerProps> | undefined;
-if (typeof window !== "undefined") {
-  import("emoji-picker-react").then(_module => {
-    EmojiPicker = _module.default;
-  });
-}
 
 export const ForumTopicPage: FC = () => {
   const { id } = useParams<{ id: string }>();
   const forumId: number | null = id ? +id : null;
   const navigate = useNavigate();
 
-  const { data: userData } = useGetUserQuery();
   const { data: currentComments } = useGetCommentsQuery(forumId ?? 0, {
     skip: !forumId,
   });
@@ -46,7 +30,6 @@ export const ForumTopicPage: FC = () => {
     forumId ?? 0,
     { skip: !forumId }
   );
-  const [addComment] = useAddCommentMutation();
 
   useEffect(() => {
     if (!forumId) {
@@ -54,37 +37,9 @@ export const ForumTopicPage: FC = () => {
     }
   }, []);
 
-  const formik = useFormik({
-    initialValues: {
-      comment: "",
-    },
-    validationSchema: commentValidation,
-    onSubmit: ({ comment }, helpers) => {
-      if (userData && forumId) {
-        addComment({ comment, topicId: forumId, authorId: userData.id });
-        helpers.setFieldValue("comment", "", false);
-      }
-      setShowPicker(false);
-    },
-  });
-
   const handleNavigateForum = () => {
     navigate(RoutesName.FORUM);
   };
-  const [showPicker, setShowPicker] = useState(false);
-  /* eslint-disable  @typescript-eslint/no-unused-vars */
-  const [chosenEmoji, setChosenEmoji] = useState<IEmojiData>();
-
-  const onEmojiClick = (
-    event: React.MouseEvent<Element, MouseEvent>,
-    emojiObject: IEmojiData
-  ) => {
-    setChosenEmoji(emojiObject); // нужно для ререндера компонента, инчае поле комментариев обновляется, только после закрытия эмоджи
-    /* eslint-disable  @typescript-eslint/no-non-null-assertion */
-    formik.values.comment = formik.values.comment + emojiObject!.emoji;
-  };
-
-  const handlePicker = () => setShowPicker(val => !val);
 
   return (
     <MainLayout>
@@ -136,65 +91,14 @@ export const ForumTopicPage: FC = () => {
             </Typography>
           </Box>
           {currentTopic && <TopicItem {...currentTopic} />}
-          <Box
-            component="form"
-            onSubmit={formik.handleSubmit}
-            sx={{
-              display: "flex",
-              flexDirection: "column",
-              alignItems: "end",
-              width: "95%",
-              my: 2,
-            }}>
-            <TextField
-              fullWidth
-              id="comment"
-              value={formik.values.comment}
-              name="comment"
-              label="Comment"
-              onChange={formik.handleChange}
-              error={formik.touched.comment && Boolean(formik.errors.comment)}
-              helperText={formik.touched.comment && formik.errors.comment}
-              multiline
-              rows={2}
-              sx={{
-                mb: 2,
-              }}
-            />
-            <Box>
-              <IconButton onClick={handlePicker}>
-                <EmojiEmotionsIcon sx={{ position: "relative" }} />
-              </IconButton>
-              {showPicker && EmojiPicker && (
-                <EmojiPicker onEmojiClick={onEmojiClick} />
-              )}
-              <Button variant="contained" size="large" type="submit">
-                Comment
-              </Button>
-            </Box>
-          </Box>
-          <List
-            sx={{
-              width: "100%",
-              overflowY: "auto",
-            }}>
-            {currentComments && currentComments.length ? (
-              currentComments
-                .map(comment => (
-                  <TopicItem
-                    description={comment.comment}
-                    key={comment.id}
-                    isBordered
-                    {...comment}
-                  />
-                ))
-                .reverse()
-            ) : (
-              <Typography variant="h6" textAlign="center">
-                No comments yet...
-              </Typography>
-            )}
-          </List>
+          <CommentForm />
+          {currentComments && currentComments.length ? (
+            <GenericList items={currentComments} renderItem={Comment} />
+          ) : (
+            <Typography variant="h6" textAlign="center">
+              No comments yet...
+            </Typography>
+          )}
         </Paper>
       )}
     </MainLayout>

--- a/packages/client/src/pages/ForumTopicPage/__snapshots__/ForumTopicPage.test.tsx.snap
+++ b/packages/client/src/pages/ForumTopicPage/__snapshots__/ForumTopicPage.test.tsx.snap
@@ -274,15 +274,11 @@ exports[`Forum Topic Page should match snapshot 1`] = `
           </button>
         </div>
       </form>
-      <ul
-        class="MuiList-root MuiList-padding css-1by5a8o-MuiList-root"
+      <h6
+        class="MuiTypography-root MuiTypography-h6 css-1kgxqm0-MuiTypography-root"
       >
-        <h6
-          class="MuiTypography-root MuiTypography-h6 css-1kgxqm0-MuiTypography-root"
-        >
-          No comments yet...
-        </h6>
-      </ul>
+        No comments yet...
+      </h6>
     </div>
   </div>
 </div>

--- a/packages/client/src/shared/constants/index.tsx
+++ b/packages/client/src/shared/constants/index.tsx
@@ -20,6 +20,13 @@ export const SERVER_URL = `http://localhost:${__SERVER_PORT__}`;
 
 export const NOT_FOUND_STATUS = 404;
 
+export const MinimizeWidth = 2;
+
+export enum CommentFrameWidth {
+  MIN = 40,
+  MAX = 100,
+}
+
 export const BasePerPage = [3, 5, 10];
 
 export const baseSpeed = 10;

--- a/packages/client/src/shared/utils/configurePluralString.ts
+++ b/packages/client/src/shared/utils/configurePluralString.ts
@@ -1,0 +1,5 @@
+export const configurePluralString = (word: string, count: number) => {
+  const str = count === 1 ? word : `${word}s`;
+
+  return `${count} ${str}`;
+};

--- a/packages/client/src/widgets/Forum/Forum.tsx
+++ b/packages/client/src/widgets/Forum/Forum.tsx
@@ -1,8 +1,6 @@
 import { ArrowForward, Search } from "@mui/icons-material";
 import {
   Box,
-  CardActionArea,
-  CardHeader,
   IconButton,
   InputAdornment,
   List,
@@ -13,13 +11,13 @@ import {
 } from "@mui/material";
 import { useFormik } from "formik";
 import { FC, useState } from "react";
-import { Link } from "react-router-dom";
 
 import {
   useAddTopicMutation,
   useGetTopicsQuery,
 } from "@/entities/forum/topics/api";
 import { AddTopic } from "@/features/AddTopic/AddTopic";
+import { GenericList } from "@/features/GenericList/GenericList";
 import { TopicItem } from "@/features/TopicItem/TopicItem";
 import { BasePerPage } from "@/shared/constants";
 import { searchValidation } from "@/shared/constants/validationShemas";
@@ -133,24 +131,12 @@ export const Forum: FC = () => {
           overflowY: "auto",
         }}>
         {filtredTopics.length ? (
-          filtredTopics.map(topic => (
-            <TopicItem
-              key={topic.id}
-              isBordered
-              {...topic}
-              header={() => (
-                <CardActionArea component={Link} to={`/forum/${topic.id}`}>
-                  <CardHeader
-                    title={
-                      <Typography variant="h5" component="h2">
-                        {topic.title}
-                      </Typography>
-                    }
-                  />
-                </CardActionArea>
-              )}
-            />
-          ))
+          <GenericList
+            renderItem={TopicItem}
+            items={filtredTopics}
+            isBordered
+            hasLink
+          />
         ) : (
           <Typography variant="h5" textAlign="center">
             No topics yet...


### PR DESCRIPTION
### Создание отображения дерева комментариев на фронте

[COS-111](https://linear.app/cosmostars/issue/COS-111/sozdat-otobrazhenie-dereva-kommentariev-na-fronte)

Задача реализована на базе ветки с контроллером комментариев

В рамках задачи реализовано:
1. Так как у нас по тз должно формироваться дерево комментариев, на фронте оно должно красиво отображаться) Сделала иерархичное отображение, для этого создала дженерик-класс, который формирует список из каких-либо компонентов какой-либо ширины
2. Отображение списка топиков на странице форума тоже сделала через созданный дженерик
3. Вынесла форму создания комментария в отдельный компонент, привязала его к дочерним комментариям - на них теперь тоже можно отвечать

P.S. Чтобы открыть или закрыть дочерние комментарии - нужно нажать на иконку комментария внизу у комментария.

### Видяшка

https://user-images.githubusercontent.com/72806681/230730169-111461a8-c427-4998-8fe3-6d6305e3b7ab.mp4


### Что будет дальше
1. Сейчас в разработке [бэкенд по лайкам](https://linear.app/cosmostars/issue/COS-87/realizaciya-kontrollera-lajkov), скоро прикрутим их на [фронт](https://linear.app/cosmostars/issue/COS-102/prikrutit-api-lajkov-na-front)
2. Если останется время - сделаем пагинацию